### PR TITLE
Add Typescript typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,6 @@
     "rollup-plugin-babel": "^2.7.1",
     "tap-dot": "^1.0.5",
     "tape": "^4.6.3"
-  }
+  },
+  "types": "./ts/rxmq.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "cover": "babel-node ./node_modules/istanbul/lib/cli cover ./node_modules/tape/bin/tape ./test",
     "build": "NODE_ENV=production rollup -c",
-    "test": "babel-node ./node_modules/tape/bin/tape ./test | tap-dot",
+    "test": "babel-node ./node_modules/tape/bin/tape ./test | tap-dot && npm run test-typings",
+    "test-typings": "./node_modules/.bin/tsc --noImplicitAny --lib es6,dom --noEmit ts/rxmq-test.ts",
     "docs": "esdoc -c esdoc.json",
     "prepublish": "npm run build"
   },
@@ -48,7 +49,8 @@
     "rollup": "^0.37.0",
     "rollup-plugin-babel": "^2.7.1",
     "tap-dot": "^1.0.5",
-    "tape": "^4.6.3"
+    "tape": "^4.6.3",
+    "typescript": "^2.1.6"
   },
   "types": "./ts/rxmq.d.ts"
 }

--- a/ts/channel.d.ts
+++ b/ts/channel.d.ts
@@ -5,18 +5,25 @@ export interface NewableSubject<U extends Subject<T>, T> {
     new(): U
 }
 
-export type RequestOptions<U extends Subject<T>, T> = {
-    topic: String,
-    data?: any,
-    Subject?: NewableSubject<U, T>
+export type RequestOptions<T, U extends Subject<R>, R> = {
+    topic: string,
+    data: T,
+    Subject?: NewableSubject<U, R>
 } 
 
-declare class Channel<T> {
-        constructor(plugins?: Array<Object>);
-        observe<T>(topic: String): Observable<T>
-        subject<T>(topic: String, subject?: EndlessSubject<T>): Subject<T>
-        request<T,U extends Subject<T>>(options: RequestOptions<U,T>): U
+declare interface BaseChannel {
+        new(plugins: Object[]): this
         registerPlugin(plugin: Object): void;
 }
 
-export default Channel;
+declare interface Channel<T> extends BaseChannel {
+        observe(topic: String): Observable<T>
+        subject(topic: String, subject?: EndlessSubject<T>): Subject<T>
+}
+
+declare interface RequestResponseChannel<Req,Res> extends BaseChannel {
+    observe(topic: String): Observable<{data: Req, replySubject: Subject<Res>}>
+    request<S extends Subject<Res>>(options: RequestOptions<Req, S, Res>): Subject<Res>
+}
+
+export  {Channel, RequestResponseChannel};

--- a/ts/channel.d.ts
+++ b/ts/channel.d.ts
@@ -1,0 +1,22 @@
+import { Observable, Subject, AsyncSubject } from 'rxjs';
+import EndlessSubject from './endlessSubject';
+
+export interface NewableSubject<T> {
+    new(): Subject<T>
+}
+
+export type RequestOptions<U extends Subject<T>, T> = {
+    topic: String,
+    data?: any,
+    Subject?: NewableSubject<T>
+} 
+
+declare class Channel<T> {
+        constructor(plugins?: Array<Object>);
+        observe<T>(topic: String): Observable<T>
+        subject<T>(topic: String, subject?: EndlessSubject<T>): Subject<T>
+        request<T,U extends Subject<T>>(options: RequestOptions<U,T>): U
+        registerPlugin(plugin: Object): void;
+}
+
+export default Channel;

--- a/ts/channel.d.ts
+++ b/ts/channel.d.ts
@@ -1,14 +1,14 @@
 import { Observable, Subject, AsyncSubject } from 'rxjs';
 import EndlessSubject from './endlessSubject';
 
-export interface NewableSubject<T> {
-    new(): Subject<T>
+export interface NewableSubject<U extends Subject<T>, T> {
+    new(): U
 }
 
 export type RequestOptions<U extends Subject<T>, T> = {
     topic: String,
     data?: any,
-    Subject?: NewableSubject<T>
+    Subject?: NewableSubject<U, T>
 } 
 
 declare class Channel<T> {

--- a/ts/endlessReplaySubject.d.ts
+++ b/ts/endlessReplaySubject.d.ts
@@ -1,0 +1,4 @@
+import { ReplaySubject } from 'rxjs';
+declare class EndlessReplaySubject<T> extends ReplaySubject<T> {}
+
+export default EndlessReplaySubject;

--- a/ts/endlessSubject.d.ts
+++ b/ts/endlessSubject.d.ts
@@ -1,0 +1,4 @@
+import { Subject } from 'rxjs';
+declare class EndlessSubject<T> extends Subject<T> {}
+
+export default EndlessSubject;

--- a/ts/rxmq-test.ts
+++ b/ts/rxmq-test.ts
@@ -1,0 +1,16 @@
+import Rxmq from './rxmq';
+import {Channel, RequestResponseChannel} from './rxmq'
+
+const messageChannel = Rxmq.channel<Channel<string>,string,void>('channel1');
+messageChannel.observe('test').subscribe(
+    (data: string) => console.log(data)
+);
+messageChannel.subject('test').next('foo');
+
+const requestChannel = Rxmq.channel<RequestResponseChannel<string,number>,string,number>('channel2');
+requestChannel.observe('test').subscribe(
+    ({data, replySubject}) => replySubject.next(data.length)
+);
+requestChannel.request({topic: 'test', data: 'foo'}).subscribe(
+        (data: number) => console.log(data)
+);

--- a/ts/rxmq.d.ts
+++ b/ts/rxmq.d.ts
@@ -1,14 +1,16 @@
-import Channel from './channel'
+import {Channel, RequestResponseChannel} from './channel'
 import EndlessSubject from './endlessSubject'
 import EndlessReplaySubject from './endlessReplaySubject'
 
+type ChannelType<T,R> = Channel<T> | RequestResponseChannel<T,R>
+
 declare namespace Rxmq {
-    function channel<T>(name: String): Channel<T>
+    function channel<T extends ChannelType<U,V>, U, V>(name: String): T
 
     function registerPlugin(plugin: Object): void
 
     function registerChannelPlugin(plugin: Object): void
 }
 
-export {Channel, EndlessSubject, EndlessReplaySubject};
+export {Channel, RequestResponseChannel, EndlessSubject, EndlessReplaySubject};
 export default Rxmq;

--- a/ts/rxmq.d.ts
+++ b/ts/rxmq.d.ts
@@ -1,0 +1,14 @@
+import Channel from './channel'
+import EndlessSubject from './endlessSubject'
+import EndlessReplaySubject from './endlessReplaySubject'
+
+declare namespace Rxmq {
+    function channel<T>(name: String): Channel<T>
+
+    function registerPlugin(plugin: Object): void
+
+    function registerChannelPlugin(plugin: Object): void
+}
+
+export {Channel, EndlessSubject, EndlessReplaySubject};
+export default Rxmq;


### PR DESCRIPTION
Hi,

I've made a first attempt at adding typings for TypeScript (see issue #12). This works fine for my use case, but there's more than meets the eye about these typings, meaning that are a few bits that might be contentious and in need of discussion :

1. I opted for making the channel generic over the type payload, but it would be possible to push this down to the topic level if desirable.
2. From the type system's perspective, there is a major distinction between whether you want to use a channel as normal pubsub one or a request/response one. So when getting a reference to a channel using Rxmq.channel(), you have to specify (as a generic bound) where you want to use it for one on the other. The underlying Channel object you get back is still the same regardless, but TypeScript will only let you use it in a certain way.

Cheers,

Niels