### PR TITLE
ts: add subject to RequestResponseChannel (#17)

### DIFF
--- a/ts/channel.d.ts
+++ b/ts/channel.d.ts
@@ -9,7 +9,7 @@ export type RequestOptions<T, U extends Subject<R>, R> = {
     topic: string,
     data: T,
     Subject?: NewableSubject<U, R>
-} 
+}
 
 declare interface BaseChannel {
         new(plugins: Object[]): this
@@ -24,6 +24,7 @@ declare interface Channel<T> extends BaseChannel {
 declare interface RequestResponseChannel<Req,Res> extends BaseChannel {
     observe(topic: String): Observable<{data: Req, replySubject: Subject<Res>}>
     request<S extends Subject<Res>>(options: RequestOptions<Req, S, Res>): Subject<Res>
+    subject(topic: String, subject?: EndlessSubject<Res>): Subject<Res>
 }
 
 export  {Channel, RequestResponseChannel};


### PR DESCRIPTION
this change allows me to compile `Rxmq.channel(name).subject(topic)` without a downcast to any.