### PR TITLE
New subscriptions for wildcard topics get events repeated twice

### DIFF
--- a/src/channel.js
+++ b/src/channel.js
@@ -1,5 +1,5 @@
 import { AsyncSubject, Observable } from 'rxjs';
-import { publishReplay, refCount, filter, mergeAll } from 'rxjs/operators';
+import { publishReplay, refCount, filter, mergeAll, share } from 'rxjs/operators';
 import { EndlessSubject, EndlessReplaySubject } from './rx/index';
 import { findSubjectByName, compareTopics } from './utils/index';
 
@@ -43,8 +43,7 @@ class Channel {
      * @private
      */
     this.channelStream = this.channelBus.pipe(
-      publishReplay(),
-      refCount()
+      share()
     );
 
     // inject plugins

--- a/src/channel.js
+++ b/src/channel.js
@@ -1,7 +1,7 @@
 import { AsyncSubject, Observable } from 'rxjs';
-import { publishReplay, refCount, filter, mergeAll, share } from 'rxjs/operators';
-import { EndlessSubject, EndlessReplaySubject } from './rx/index';
-import { findSubjectByName, compareTopics } from './utils/index';
+import { filter, mergeAll } from 'rxjs/operators';
+import { EndlessReplaySubject, EndlessSubject } from './rx/index';
+import { compareTopics, findSubjectByName } from './utils/index';
 
 /**
  * Rxmq channel class
@@ -42,9 +42,7 @@ class Channel {
      * @type {Observable}
      * @private
      */
-    this.channelStream = this.channelBus.pipe(
-      share()
-    );
+    this.channelStream = this.channelBus;
 
     // inject plugins
     plugins.map(this.registerPlugin.bind(this));

--- a/test/rxmq.js
+++ b/test/rxmq.js
@@ -116,7 +116,6 @@ test('RxMQ', it => {
     });
 
     subit.test('should not republish the same message multiple times', t => {
-      console.log('Running this test!!!');
       const chan = Rxmq.channel('repubmultipletimestest');
       const testData1 = 'test-data-1';
 


### PR DESCRIPTION
Issue faced:
* Documented in test "should not republish the same message multiple times on unsubscribing to a topic and resubscribing"
* Consider a consumer c1 which subscribes to a wildcard of topics
* After some time c1 unsubscribes
* Now, another consumer c2 subscribes to the same wildcard of topics
* Bug: c2 will observe all subsequent published events twice

Bug cause:
* For new subscribers after completion, `publishReplay` + `refCount` replays all events and then sets up a new subscription to the source
* The source in this case is a `EndlessReplaySubject` which on any new subscription, replays all its events
* Hence any observers of this observable will get the events twice
* The "events" in this case are the topic subjects, which are merged and sent to c2 twice
* More details here ("Differences between shareReplay({refCount: true}) and publishReplay() + refCount()"): https://itnext.io/the-magic-of-rxjs-sharing-operators-and-their-differences-3a03d699d255

Bug fix:
* One option is to replace `publishReplay` and `refCount` with `shareReplay`. But then `channelBus` is already a `EndlessReplaySubject`
* Hence, the fix is to just remove `publishReplay` and `refCount`
